### PR TITLE
Removed keep alive scripts

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,7 +1,6 @@
 [
   "hubot-diagnostics",
   "hubot-help",
-  "hubot-heroku-keepalive",
   "hubot-google-images",
   "hubot-google-translate",
   "hubot-pugme",
@@ -11,5 +10,4 @@
   "hubot-shipit",
   "hubot-youtube",
   "hubot-dogeme",
-  "hubot-heroku-keepalive"
 ]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "hubot-google-images": "^0.1.3",
     "hubot-google-translate": "^0.1.0",
     "hubot-help": "^0.1.1",
-    "hubot-heroku-keepalive": "0.0.4",
     "hubot-maps": "0.0.1",
     "hubot-pugme": "^0.1.0",
     "hubot-redis-brain": "0.0.2",


### PR DESCRIPTION
Hubot dyno upgraded to a hobby one. This doesn't sleep after 30 minutes of inactivity so the keep alive plugin is no longer needed
